### PR TITLE
Add support for i18n features

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,32 @@ import 'assets.dart'
 Text(I18n.of(context).hello)
 ```
 
+#### Organize I18n strings by feature
+
+It is possible to organize i18n strings by feature so that they are not stored in one huge file.
+
+1. Add default localization file and feature definitions to `pubspec.yaml`
+```yaml
+r_flutter:
+  intl: lib/i18n/en.arb
+  intl_features:
+    - name: home
+      path: lib/custom/path/to/home/
+    - name: announcement
+    - name: profile
+```
+
+If a path is not specified it is assumed to be a subdirectory of the main intl file directory. In this example the announcement and profile translation files will be placed under `lib/i18n/announcement/` and `lib/i18n/profile/` respectively.
+
+2. Create the actual translation files for the features and run the generator as usual.
+
+3. Use it
+```dart
+import 'assets.dart'
+Text(I18n.of(context).home.hello)
+```
+
+
 ### Custom asset classes
 
 r_flutter supports third party packages like flutter_svg by providing option to convert generated constants directly into the desired class. To use it, you need to configure which file extension should by handled by which class, for example:

--- a/bin/generate.dart
+++ b/bin/generate.dart
@@ -14,7 +14,7 @@ void main(List<String> args) {
 
   final configRaw = safeCast<YamlMap>(
       loadYaml(File(arguments.pubspecFilename).absolute.readAsStringSync()));
-  final config = Config.parsePubspecConfig(configRaw ?? YamlMap());
+  final config = Config.fromPubspec(configRaw ?? YamlMap());
 
   final res = parseResources(config);
   final contents = generateFile(res, config);

--- a/bin/generate.dart
+++ b/bin/generate.dart
@@ -19,10 +19,10 @@ void main(List<String> args) {
   final res = parseResources(config);
   final contents = generateFile(res, config);
 
-  final outoutFile = File(arguments.outputFilename);
-  outoutFile.writeAsStringSync(contents);
+  final outputFile = File(arguments.outputFilename);
+  outputFile.writeAsStringSync(contents);
 
-  print("${outoutFile.path} generated successfully");
+  print("${outputFile.path} generated successfully");
 }
 
 class CommandLineArguments {

--- a/lib/builder.dart
+++ b/lib/builder.dart
@@ -26,6 +26,8 @@ Resources parseResources(Config arguments) {
     fonts: parseFonts(yaml),
     assets: parseAssets(yaml, arguments.ignoreAssets, arguments.assetClasses),
     i18n: parseStrings(arguments.intlFilename),
+    i18nFeatures:
+        parseFeatureStrings(arguments.intlFilename, arguments.i18nFeatures),
   );
 }
 

--- a/lib/builder.dart
+++ b/lib/builder.dart
@@ -87,14 +87,14 @@ class AssetsBuilder extends Builder {
       buildStep.canRead(file);
     }
 
-    for (final feature in arguments.i18nFeatures) {
-      final directory = getDirectoryForFeature(feature, intlFilename);
+    arguments.i18nFeatures.forEach((name, path) async {
+      final directory = getDirectoryForFeature(name, path, intlFilename);
       final featureGlob = Glob(join(directory, '*'));
       final featureFiles = await buildStep.findAssets(featureGlob).toList();
       for (final file in featureFiles) {
         buildStep.canRead(file);
       }
-    }
+    });
   }
 
   @override

--- a/lib/builder.dart
+++ b/lib/builder.dart
@@ -50,7 +50,7 @@ class AssetsBuilder extends Builder {
 
     final configRaw =
         safeCast<YamlMap>(loadYaml(await buildStep.readAsString(configId)));
-    final config = Config.parsePubspecConfig(configRaw ?? YamlMap());
+    final config = Config.fromPubspec(configRaw ?? YamlMap());
 
     await _markIntlFiles(buildStep, config);
 

--- a/lib/builder.dart
+++ b/lib/builder.dart
@@ -86,6 +86,15 @@ class AssetsBuilder extends Builder {
     for (final file in files) {
       buildStep.canRead(file);
     }
+
+    for (final feature in arguments.i18nFeatures) {
+      final directory = getDirectoryForFeature(feature, intlFilename);
+      final featureGlob = Glob(join(directory, '*'));
+      final featureFiles = await buildStep.findAssets(featureGlob).toList();
+      for (final file in featureFiles) {
+        buildStep.canRead(file);
+      }
+    }
   }
 
   @override

--- a/lib/builder.dart
+++ b/lib/builder.dart
@@ -4,6 +4,7 @@ import 'dart:io';
 import 'package:build/build.dart';
 import 'package:glob/glob.dart';
 import 'package:path/path.dart';
+import 'package:r_flutter/src/model/i18n.dart';
 import 'package:r_flutter/src/parser/i18n/i18n_parser.dart';
 import 'package:r_flutter/src/utils/utils.dart';
 import 'package:yaml/yaml.dart';
@@ -22,12 +23,32 @@ Resources parseResources(Config arguments) {
 
   final yaml = loadYaml(pubspecFile.readAsStringSync()) as YamlMap;
 
+  final primaryLocales = parseStrings(arguments.intlFilename);
+  final featureLocales =
+      parseFeatureStrings(arguments.intlFilename, arguments.i18nFeatures);
+
+  if (primaryLocales != null && featureLocales != null) {
+    // Make sure feature-only locales are added to the primary locale list.
+    final featureOnlyLocales = <Locale>[];
+    for (final feature in featureLocales) {
+      for (final locale in feature.locales.locales) {
+        if (!primaryLocales.locales.any((e) => e.locale == locale.locale)) {
+          featureOnlyLocales.add(locale.locale);
+        }
+      }
+    }
+
+    if (featureOnlyLocales.isNotEmpty) {
+      primaryLocales.locales
+          .addAll(featureOnlyLocales.map((e) => I18nLocale(e, [])));
+    }
+  }
+
   return Resources(
     fonts: parseFonts(yaml),
     assets: parseAssets(yaml, arguments.ignoreAssets, arguments.assetClasses),
-    i18n: parseStrings(arguments.intlFilename),
-    i18nFeatures:
-        parseFeatureStrings(arguments.intlFilename, arguments.i18nFeatures),
+    i18n: primaryLocales,
+    i18nFeatures: featureLocales,
   );
 }
 

--- a/lib/src/arguments.dart
+++ b/lib/src/arguments.dart
@@ -7,12 +7,14 @@ class Config {
   final List<String> ignoreAssets;
   final String? intlFilename;
   final List<CustomAssetType> assetClasses;
+  final List<I18nFeature> i18nFeatures;
 
   Config._({
     required this.pubspecFilename,
     this.intlFilename,
     this.ignoreAssets = const [],
     this.assetClasses = const [],
+    this.i18nFeatures = const [],
   });
 
   factory Config.fromPubspec(YamlMap yaml) {
@@ -31,6 +33,20 @@ class Config {
             .cast<String>() ??
         [];
     final intlFilename = safeCast<String>(rFlutterConfig['intl']);
+
+    final features = safeCast<YamlList>(rFlutterConfig['intl_features'])
+            ?.map((e) => safeCast<YamlMap>(e))
+            .where((e) => e != null)
+            .cast<YamlMap>()
+            .where((e) => e['name'] != null && e['name'] is String)
+            .map(
+              (e) => I18nFeature(
+                name: safeCast<String>(e['name'])!,
+                path: safeCast<String>(e['path']),
+              ),
+            )
+            .toList() ??
+        [];
 
     final assetClasses = safeCast<YamlMap>(rFlutterConfig['asset_classes']);
     final classes = <CustomAssetType>[];
@@ -59,6 +75,7 @@ class Config {
       ignoreAssets: ignoreAssets,
       intlFilename: intlFilename,
       assetClasses: classes,
+      i18nFeatures: features,
     );
   }
 }

--- a/lib/src/arguments.dart
+++ b/lib/src/arguments.dart
@@ -3,29 +3,34 @@ import 'package:r_flutter/src/utils/utils.dart';
 import 'package:yaml/yaml.dart';
 
 class Config {
-  late String pubspecFilename;
-  List<String> ignoreAssets = [];
-  String? intlFilename;
-  List<CustomAssetType> assetClasses = [];
+  final String pubspecFilename;
+  final List<String> ignoreAssets;
+  final String? intlFilename;
+  final List<CustomAssetType> assetClasses;
 
-  Config();
+  Config._({
+    required this.pubspecFilename,
+    this.intlFilename,
+    this.ignoreAssets = const [],
+    this.assetClasses = const [],
+  });
 
-  factory Config.parsePubspecConfig(YamlMap yaml) {
-    final arguments = Config()..pubspecFilename = 'pubspec.yaml';
+  factory Config.fromPubspec(YamlMap yaml) {
+    const pubspecFilename = 'pubspec.yaml';
 
     final rFlutterConfig = safeCast<YamlMap>(yaml["r_flutter"]);
     if (rFlutterConfig == null) {
-      return arguments;
+      return Config._(pubspecFilename: pubspecFilename);
     }
 
     final ignoreRaw = safeCast<YamlList>(rFlutterConfig['ignore']);
-    arguments.ignoreAssets = ignoreRaw
+    final ignoreAssets = ignoreRaw
             ?.map((x) => safeCast<String>(x))
             .where((it) => it != null)
             .toList()
             .cast<String>() ??
         [];
-    arguments.intlFilename = safeCast<String>(rFlutterConfig['intl']);
+    final intlFilename = safeCast<String>(rFlutterConfig['intl']);
 
     final assetClasses = safeCast<YamlMap>(rFlutterConfig['asset_classes']);
     final classes = <CustomAssetType>[];
@@ -48,8 +53,12 @@ class Config {
 
       classes.add(CustomAssetType(className, keyString, import));
     }
-    arguments.assetClasses = classes;
 
-    return arguments;
+    return Config._(
+      pubspecFilename: pubspecFilename,
+      ignoreAssets: ignoreAssets,
+      intlFilename: intlFilename,
+      assetClasses: classes,
+    );
   }
 }

--- a/lib/src/arguments.dart
+++ b/lib/src/arguments.dart
@@ -7,14 +7,14 @@ class Config {
   final List<String> ignoreAssets;
   final String? intlFilename;
   final List<CustomAssetType> assetClasses;
-  final List<I18nFeature> i18nFeatures;
+  final Map<String, String?> i18nFeatures;
 
   Config._({
     required this.pubspecFilename,
     this.intlFilename,
     this.ignoreAssets = const [],
     this.assetClasses = const [],
-    this.i18nFeatures = const [],
+    this.i18nFeatures = const {},
   });
 
   factory Config.fromPubspec(YamlMap yaml) {
@@ -34,19 +34,18 @@ class Config {
         [];
     final intlFilename = safeCast<String>(rFlutterConfig['intl']);
 
-    final features = safeCast<YamlList>(rFlutterConfig['intl_features'])
+    final featureList = safeCast<YamlList>(rFlutterConfig['intl_features'])
             ?.map((e) => safeCast<YamlMap>(e))
             .where((e) => e != null)
             .cast<YamlMap>()
             .where((e) => e['name'] != null && e['name'] is String)
-            .map(
-              (e) => I18nFeature(
-                name: safeCast<String>(e['name'])!,
-                path: safeCast<String>(e['path']),
-              ),
-            )
             .toList() ??
         [];
+
+    final features = {
+      for (var e in featureList)
+        safeCast<String>(e['name'])!: safeCast<String>(e['path'])
+    };
 
     final assetClasses = safeCast<YamlMap>(rFlutterConfig['asset_classes']);
     final classes = <CustomAssetType>[];

--- a/lib/src/generator/generator.dart
+++ b/lib/src/generator/generator.dart
@@ -10,7 +10,7 @@ import 'i18n/generator.dart';
 String generateFile(Resources res, Config arguments) {
   final classes = <DartClass>[];
   if (res.i18n != null) {
-    classes.addAll(generateI18nClasses(res.i18n!));
+    classes.addAll(generateI18nClasses(res.i18n!, res.i18nFeatures));
   }
   final fontClass = generateFontClass(res.fonts);
   if (fontClass != null) {

--- a/lib/src/generator/i18n/generator.dart
+++ b/lib/src/generator/i18n/generator.dart
@@ -13,7 +13,7 @@ List<DartClass> generateI18nClasses(
   return [
     generateI18nClass(i18n),
     ...generateI18nKeysClasses(i18n, i18nFeatures),
-    ...generateLookupClasses(i18n),
+    ...generateLookupClasses(i18n, i18nFeatures),
     generateI18nDelegate(i18n)
   ];
 }

--- a/lib/src/generator/i18n/generator.dart
+++ b/lib/src/generator/i18n/generator.dart
@@ -6,10 +6,13 @@ import 'package:r_flutter/src/model/i18n.dart';
 import 'delegate_generator.dart';
 import 'keys_generator.dart';
 
-List<DartClass> generateI18nClasses(I18nLocales i18n) {
+List<DartClass> generateI18nClasses(
+  I18nLocales i18n,
+  Map<String, I18nLocales>? i18nFeatures,
+) {
   return [
     generateI18nClass(i18n),
-    generateI18nKeysClass(i18n),
+    ...generateI18nKeysClasses(i18n, i18nFeatures),
     ...generateLookupClasses(i18n),
     generateI18nDelegate(i18n)
   ];

--- a/lib/src/generator/i18n/generator.dart
+++ b/lib/src/generator/i18n/generator.dart
@@ -8,7 +8,7 @@ import 'keys_generator.dart';
 
 List<DartClass> generateI18nClasses(
   I18nLocales i18n,
-  Map<String, I18nLocales>? i18nFeatures,
+  List<I18nFeature>? i18nFeatures,
 ) {
   return [
     ...generateI18nMainClasses(i18n, i18nFeatures),

--- a/lib/src/generator/i18n/generator.dart
+++ b/lib/src/generator/i18n/generator.dart
@@ -1,9 +1,9 @@
-import 'package:r_flutter/src/generator/i18n/i18n_generator.dart';
 import 'package:r_flutter/src/generator/i18n/lookup_generator.dart';
 import 'package:r_flutter/src/model/dart_class.dart';
 import 'package:r_flutter/src/model/i18n.dart';
 
 import 'delegate_generator.dart';
+import 'i18n_generator.dart';
 import 'keys_generator.dart';
 
 List<DartClass> generateI18nClasses(
@@ -11,7 +11,7 @@ List<DartClass> generateI18nClasses(
   Map<String, I18nLocales>? i18nFeatures,
 ) {
   return [
-    generateI18nClass(i18n),
+    ...generateI18nMainClasses(i18n, i18nFeatures),
     ...generateI18nKeysClasses(i18n, i18nFeatures),
     ...generateLookupClasses(i18n, i18nFeatures),
     generateI18nDelegate(i18n)

--- a/lib/src/generator/i18n/i18n_generator.dart
+++ b/lib/src/generator/i18n/i18n_generator.dart
@@ -80,9 +80,9 @@ DartClass generateI18nFeatureClass(I18nLocales i18n, String feature) {
 /// ```
 ///
 DartClass generateI18nClass(
-  I18nLocales i18n,
+  I18nLocales i18n, [
   Iterable<String>? features,
-) {
+]) {
   final classString = StringBuffer("""class I18n {
   final I18nLookup _lookup;
 

--- a/lib/src/generator/i18n/i18n_generator.dart
+++ b/lib/src/generator/i18n/i18n_generator.dart
@@ -112,6 +112,13 @@ DartClass generateI18nClass(
     final className = 'I18n${ReCase(feature).pascalCase}';
     final propertyName = ReCase(feature).camelCase;
 
+    if (i18n.defaultValues.strings
+        .any((e) => e.escapedKey.toLowerCase() == propertyName.toLowerCase())) {
+      throw StateError(
+        'There is a string and a feature with the same name: $propertyName',
+      );
+    }
+
     classString.writeln('  final $className $propertyName;');
     classString.writeln();
   });

--- a/lib/src/generator/i18n/keys_generator.dart
+++ b/lib/src/generator/i18n/keys_generator.dart
@@ -1,5 +1,6 @@
 import 'package:r_flutter/src/model/dart_class.dart';
 import 'package:r_flutter/src/model/i18n.dart';
+import 'package:recase/recase.dart';
 
 ///
 /// ```dart
@@ -9,14 +10,58 @@ import 'package:r_flutter/src/model/i18n.dart';
 /// }
 /// ```
 ///
-DartClass generateI18nKeysClass(I18nLocales locales) {
-  final classString = StringBuffer("class I18nKeys {\n");
+List<DartClass> generateI18nKeysClasses(
+  I18nLocales locales, [
+  Map<String, I18nLocales>? i18nFeatures,
+]) {
+  final featureClassNames = <String, String>{};
+  final featureClasses = <DartClass>[];
+
+  i18nFeatures?.forEach((featureName, locales) {
+    final featureClassName = 'I18n${ReCase(featureName).pascalCase}Keys';
+    featureClassNames[featureName] = featureClassName;
+
+    featureClasses
+        .add(_generateI18nKeysClass(locales, className: featureClassName));
+  });
+
+  return <DartClass>[
+    _generateI18nKeysClass(locales, featureClassNames: featureClassNames),
+    ...featureClasses
+  ];
+}
+
+DartClass _generateI18nKeysClass(
+  I18nLocales locales, {
+  String? className,
+  Map<String, String>? featureClassNames,
+}) {
+  final classString = StringBuffer("class ${className ?? 'I18nKeys'} {\n");
+
+  if (className != null) {
+    classString.writeln('  const $className();');
+  }
 
   final items = locales.defaultValues.strings;
   for (final item in items) {
     classString
-        .writeln("  static const String ${item.escapedKey} = \"${item.key}\";");
+        .writeln('  static const String ${item.escapedKey} = "${item.key}";');
   }
+
+  featureClassNames?.forEach((featureName, featureClassName) {
+    final propertyName = ReCase(featureName).camelCase;
+
+    if (items
+        .any((e) => e.escapedKey.toLowerCase() == propertyName.toLowerCase())) {
+      throw StateError(
+        'There is a string and a feature with the same name: $propertyName',
+      );
+    }
+
+    classString.writeln(
+      '  static const $featureClassName $propertyName = $featureClassName();',
+    );
+  });
 
   classString.writeln("}");
   return DartClass(code: classString.toString());

--- a/lib/src/generator/i18n/keys_generator.dart
+++ b/lib/src/generator/i18n/keys_generator.dart
@@ -1,6 +1,5 @@
 import 'package:r_flutter/src/model/dart_class.dart';
 import 'package:r_flutter/src/model/i18n.dart';
-import 'package:recase/recase.dart';
 
 ///
 /// ```dart
@@ -12,17 +11,17 @@ import 'package:recase/recase.dart';
 ///
 List<DartClass> generateI18nKeysClasses(
   I18nLocales locales, [
-  Map<String, I18nLocales>? i18nFeatures,
+  List<I18nFeature>? i18nFeatures,
 ]) {
   final featureClassNames = <String, String>{};
   final featureClasses = <DartClass>[];
 
-  i18nFeatures?.forEach((featureName, locales) {
-    final featureClassName = 'I18n${ReCase(featureName).pascalCase}Keys';
-    featureClassNames[featureName] = featureClassName;
+  i18nFeatures?.forEach((feature) {
+    final featureClassName = 'I18n${feature.featureClassName}Keys';
+    featureClassNames[feature.featureClassName] = featureClassName;
 
-    featureClasses
-        .add(_generateI18nKeysClass(locales, className: featureClassName));
+    featureClasses.add(
+        _generateI18nKeysClass(feature.locales, className: featureClassName));
   });
 
   return <DartClass>[

--- a/lib/src/generator/i18n/keys_generator.dart
+++ b/lib/src/generator/i18n/keys_generator.dart
@@ -38,10 +38,6 @@ DartClass _generateI18nKeysClass(
 }) {
   final classString = StringBuffer("class ${className ?? 'I18nKeys'} {\n");
 
-  if (className != null) {
-    classString.writeln('  const $className();');
-  }
-
   final items = locales.defaultValues.strings;
   for (final item in items) {
     classString
@@ -57,10 +53,6 @@ DartClass _generateI18nKeysClass(
         'There is a string and a feature with the same name: $propertyName',
       );
     }
-
-    classString.writeln(
-      '  static const $featureClassName $propertyName = $featureClassName();',
-    );
   });
 
   classString.writeln("}");

--- a/lib/src/generator/i18n/keys_generator.dart
+++ b/lib/src/generator/i18n/keys_generator.dart
@@ -44,17 +44,6 @@ DartClass _generateI18nKeysClass(
         .writeln('  static const String ${item.escapedKey} = "${item.key}";');
   }
 
-  featureClassNames?.forEach((featureName, featureClassName) {
-    final propertyName = ReCase(featureName).camelCase;
-
-    if (items
-        .any((e) => e.escapedKey.toLowerCase() == propertyName.toLowerCase())) {
-      throw StateError(
-        'There is a string and a feature with the same name: $propertyName',
-      );
-    }
-  });
-
   classString.writeln("}");
   return DartClass(code: classString.toString());
 }

--- a/lib/src/generator/i18n/lookup_generator.dart
+++ b/lib/src/generator/i18n/lookup_generator.dart
@@ -2,11 +2,10 @@ import 'package:collection/collection.dart';
 import 'package:r_flutter/src/generator/i18n/i18n_generator_utils.dart';
 import 'package:r_flutter/src/model/dart_class.dart';
 import 'package:r_flutter/src/model/i18n.dart';
-import 'package:recase/recase.dart';
 
 List<DartClass> generateLookupClasses(
   I18nLocales i18n,
-  Map<String, I18nLocales>? i18nFeatures,
+  List<I18nFeature>? i18nFeatures,
 ) {
   final classes = <DartClass>[];
 
@@ -14,16 +13,16 @@ List<DartClass> generateLookupClasses(
     generateDefaultLookupClass(
       i18n,
       i18n.defaultValues,
-      features: i18nFeatures?.keys,
+      features: i18nFeatures,
     ),
   );
 
-  i18nFeatures?.forEach((featureName, locales) {
+  i18nFeatures?.forEach((feature) {
     classes.add(
       generateDefaultLookupClass(
-        locales,
-        locales.defaultValues,
-        featureName: featureName,
+        feature.locales,
+        feature.locales.defaultValues,
+        feature: feature,
       ),
     );
   });
@@ -33,18 +32,18 @@ List<DartClass> generateLookupClasses(
       generateLookupClass(
         i18n,
         locale,
-        features: i18nFeatures?.keys,
+        features: i18nFeatures,
       ),
     );
   }
 
-  i18nFeatures?.forEach((featureName, locales) {
-    for (final locale in locales.locales) {
+  i18nFeatures?.forEach((feature) {
+    for (final locale in feature.locales.locales) {
       classes.add(
         generateLookupClass(
-          locales,
+          feature.locales,
           locale,
-          featureName: featureName,
+          feature: feature,
         ),
       );
     }
@@ -73,11 +72,10 @@ List<DartClass> generateLookupClasses(
 DartClass generateDefaultLookupClass(
   I18nLocales i18n,
   I18nLocale value, {
-  Iterable<String>? features,
-  String? featureName,
+  List<I18nFeature>? features,
+  I18nFeature? feature,
 }) {
-  final featureClassName =
-      featureName != null ? ReCase(featureName).pascalCase : '';
+  final featureClassName = feature != null ? feature.featureClassName : '';
   final code = StringBuffer(
     "class I18n${featureClassName}Lookup",
   );
@@ -143,7 +141,7 @@ DartClass generateDefaultLookupClass(
   }
 
   features?.forEach((feature) {
-    final featureClass = ReCase(feature).pascalCase;
+    final featureClass = feature.featureClassName;
     final className = 'I18n${featureClass}Lookup';
 
     code.writeln();
@@ -167,11 +165,10 @@ DartClass generateDefaultLookupClass(
 DartClass generateLookupClass(
   I18nLocales i18n,
   I18nLocale value, {
-  Iterable<String>? features,
-  String? featureName,
+  List<I18nFeature>? features,
+  I18nFeature? feature,
 }) {
-  final featureClassName =
-      featureName != null ? ReCase(featureName).pascalCase : '';
+  final featureClassName = feature != null ? feature.featureClassName : '';
   final code = StringBuffer("class I18n${featureClassName}Lookup");
 
   code.write("_${value.locale}");
@@ -220,7 +217,7 @@ DartClass generateLookupClass(
   }
 
   features?.forEach((feature) {
-    final featureClass = ReCase(feature).pascalCase;
+    final featureClass = feature.featureClassName;
     final className = 'I18n${featureClass}Lookup_${value.locale}';
     code.writeln();
     code.writeln('  @override');

--- a/lib/src/generator/i18n/lookup_generator.dart
+++ b/lib/src/generator/i18n/lookup_generator.dart
@@ -217,6 +217,11 @@ DartClass generateLookupClass(
   }
 
   features?.forEach((feature) {
+    // Check if this feature supports the current locale.
+    if (!feature.locales.locales.any((e) => e.locale == value.locale)) {
+      return;
+    }
+
     final featureClass = feature.featureClassName;
     final className = 'I18n${featureClass}Lookup_${value.locale}';
     code.writeln();

--- a/lib/src/generator/i18n/lookup_generator.dart
+++ b/lib/src/generator/i18n/lookup_generator.dart
@@ -2,60 +2,95 @@ import 'package:collection/collection.dart';
 import 'package:r_flutter/src/generator/i18n/i18n_generator_utils.dart';
 import 'package:r_flutter/src/model/dart_class.dart';
 import 'package:r_flutter/src/model/i18n.dart';
+import 'package:recase/recase.dart';
 
-List<DartClass> generateLookupClasses(I18nLocales i18n) {
+List<DartClass> generateLookupClasses(
+  I18nLocales i18n,
+  Map<String, I18nLocales>? i18nFeatures,
+) {
   final classes = <DartClass>[];
 
-  classes.add(generateLookupClass(
-    i18n: i18n,
-    value: i18n.defaultValues,
-    isDefaultClass: true,
-  ));
+  classes.add(
+    generateDefaultLookupClass(
+      i18n,
+      i18n.defaultValues,
+      features: i18nFeatures?.keys,
+    ),
+  );
+
+  i18nFeatures?.forEach((featureName, locales) {
+    classes.add(
+      generateDefaultLookupClass(
+        locales,
+        locales.defaultValues,
+        featureName: featureName,
+      ),
+    );
+  });
 
   for (final locale in i18n.locales) {
-    classes.add(generateLookupClass(
-      i18n: i18n,
-      value: locale,
-      isDefaultClass: false,
-    ));
+    classes.add(
+      generateLookupClass(
+        i18n,
+        locale,
+        features: i18nFeatures?.keys,
+      ),
+    );
   }
+
+  i18nFeatures?.forEach((featureName, locales) {
+    for (final locale in locales.locales) {
+      classes.add(
+        generateLookupClass(
+          locales,
+          locale,
+          featureName: featureName,
+        ),
+      );
+    }
+  });
 
   return classes;
 }
 
 ///
 /// ```dart
-/// class I18nLookup_de_AT extends I18nLookup_de {
-///  @override
-///  String get string1 {
-///    return "Text_AT";
-///  }
+/// class I18nLookup {
+///   String getString(String key, [Map<String, String>? placeholders]) {
+///     throw UnimplementedError("I18nLookup.getString");
+///   }
+///
+///   String get hello {
+///     return getString(I18nKeys.hello);
+///   }
+///
+///   String get world {
+///     return getString(I18nKeys.world);
+///   }
 /// }
 /// ```
 ///
-DartClass generateLookupClass(
-    {required I18nLocales i18n,
-    required I18nLocale value,
-    required bool isDefaultClass}) {
-  final code = StringBuffer("class I18nLookup");
+DartClass generateDefaultLookupClass(
+  I18nLocales i18n,
+  I18nLocale value, {
+  Iterable<String>? features,
+  String? featureName,
+}) {
+  final featureClassName =
+      featureName != null ? ReCase(featureName).pascalCase : '';
+  final code = StringBuffer(
+    "class I18n${featureClassName}Lookup",
+  );
 
-  if (!isDefaultClass) {
-    code.write("_${value.locale}");
-    code.write(" extends I18nLookup");
-
-    final parent = _findParent(i18n, value);
-    if (parent != null) {
-      code.write("_${parent.locale}");
-    }
-  }
   code.write(" {\n");
 
-  if (isDefaultClass) {
-    code.writeln(
-        "  String getString(String key, [Map<String, String>? placeholders]) {");
-    code.writeln("    throw UnimplementedError(\"I18nLookup.getString\");");
-    code.writeln("  }\n");
-  }
+  code.writeln(
+    "  String getString(String key, [Map<String, String>? placeholders]) {",
+  );
+  code.writeln(
+    '    throw UnimplementedError("I18n${featureClassName}Lookup.getString");',
+  );
+  code.writeln("  }\n");
 
   bool isFirstMethod = true;
   final defaultLocale = i18n.defaultValues;
@@ -77,46 +112,120 @@ DartClass generateLookupClass(
     }
     isFirstMethod = false;
 
-    if (isDefaultClass) {
-      final methodCode =
-          StringBuffer("    return getString(I18nKeys.${item.escapedKey}");
+    final methodCode = StringBuffer(
+      "    return getString(I18n${featureClassName}Keys.${item.escapedKey}",
+    );
 
-      if (defaultItem.placeholders.isNotEmpty) {
-        methodCode.write(", {");
+    if (defaultItem.placeholders.isNotEmpty) {
+      methodCode.write(", {");
 
-        var isFirstPlaceholder = true;
-        for (final placeholder in defaultItem.placeholders) {
-          if (!isFirstPlaceholder) {
-            methodCode.write(", ");
-          }
-          isFirstPlaceholder = false;
-          methodCode.write("\"$placeholder\": $placeholder");
+      var isFirstPlaceholder = true;
+      for (final placeholder in defaultItem.placeholders) {
+        if (!isFirstPlaceholder) {
+          methodCode.write(", ");
         }
-
-        methodCode.write("});");
-      } else {
-        methodCode.write(");");
+        isFirstPlaceholder = false;
+        methodCode.write('"$placeholder": $placeholder');
       }
 
-      code.write(generateMethod(
+      methodCode.write("});");
+    } else {
+      methodCode.write(");");
+    }
+
+    code.write(
+      generateMethod(
         name: defaultItem.escapedKey,
         parameters: defaultItem.placeholders,
         code: methodCode.toString(),
-      ));
-    } else {
-      String valueString = item.value;
-      valueString = escapeStringLiteral(valueString);
-      for (final placeholder in defaultItem.placeholders) {
-        valueString =
-            valueString.replaceAll("{$placeholder}", "\${$placeholder}");
-      }
-      code.writeln("  @override");
-      code.write(generateMethod(
-          name: defaultItem.escapedKey,
-          parameters: defaultItem.placeholders,
-          code: "    return \"$valueString\";"));
-    }
+      ),
+    );
   }
+
+  features?.forEach((feature) {
+    final featureClass = ReCase(feature).pascalCase;
+    final className = 'I18n${featureClass}Lookup';
+
+    code.writeln();
+    code.writeln('  $className create${featureClass}Lookup() => $className();');
+  });
+
+  code.writeln("}");
+  return DartClass(code: code.toString());
+}
+
+///
+/// ```dart
+/// class I18nLookup_de_AT extends I18nLookup_de {
+///  @override
+///  String get string1 {
+///    return "Text_AT";
+///  }
+/// }
+/// ```
+///
+DartClass generateLookupClass(
+  I18nLocales i18n,
+  I18nLocale value, {
+  Iterable<String>? features,
+  String? featureName,
+}) {
+  final featureClassName =
+      featureName != null ? ReCase(featureName).pascalCase : '';
+  final code = StringBuffer("class I18n${featureClassName}Lookup");
+
+  code.write("_${value.locale}");
+  code.write(" extends I18n${featureClassName}Lookup");
+
+  final parent = _findParent(i18n, value);
+  if (parent != null) {
+    code.write("_${parent.locale}");
+  }
+  code.writeln(" {");
+
+  bool isFirstMethod = true;
+  final defaultLocale = i18n.defaultValues;
+  for (final item in value.strings) {
+    I18nString? defaultItem;
+    if (value != defaultLocale) {
+      defaultItem =
+          defaultLocale.strings.firstWhereOrNull((it) => it.key == item.key);
+    } else {
+      defaultItem = item;
+    }
+
+    if (defaultItem == null) {
+      continue;
+    }
+
+    if (!isFirstMethod) {
+      code.writeln();
+    }
+    isFirstMethod = false;
+
+    String valueString = item.value;
+    valueString = escapeStringLiteral(valueString);
+    for (final placeholder in defaultItem.placeholders) {
+      valueString =
+          valueString.replaceAll("{$placeholder}", "\${$placeholder}");
+    }
+    code.writeln("  @override");
+    code.write(
+      generateMethod(
+        name: defaultItem.escapedKey,
+        parameters: defaultItem.placeholders,
+        code: '    return "$valueString";',
+      ),
+    );
+  }
+
+  features?.forEach((feature) {
+    final featureClass = ReCase(feature).pascalCase;
+    final className = 'I18n${featureClass}Lookup_${value.locale}';
+    code.writeln();
+    code.writeln('  @override');
+    code.writeln('  $className create${featureClass}Lookup() => $className();');
+  });
 
   code.writeln("}");
   return DartClass(code: code.toString());

--- a/lib/src/model/i18n.dart
+++ b/lib/src/model/i18n.dart
@@ -1,3 +1,5 @@
+import 'package:recase/recase.dart';
+
 class Locale {
   final String languageCode;
   final String? countryCode;
@@ -65,4 +67,16 @@ class I18nString {
 
   String get escapedKey =>
       key.replaceAll(".", "_").replaceAll("-", "_").replaceAll(" ", "_");
+}
+
+class I18nFeature {
+  I18nFeature({required this.locales, required this.name, this.path})
+      : featureClassName = ReCase(name).pascalCase,
+        featurePropertyName = ReCase(name).camelCase;
+
+  final String name;
+  final String? path;
+  final I18nLocales locales;
+  final String featureClassName;
+  final String featurePropertyName;
 }

--- a/lib/src/model/resources.dart
+++ b/lib/src/model/resources.dart
@@ -4,11 +4,13 @@ class Resources {
   final List<String> fonts;
   final Assets assets;
   final I18nLocales? i18n;
+  final Map<String, I18nLocales>? i18nFeatures;
 
   Resources({
     required this.fonts,
     required this.assets,
     this.i18n,
+    this.i18nFeatures,
   });
 }
 
@@ -82,4 +84,11 @@ class CustomAssetType extends AssetType {
 
   const CustomAssetType(this.customClass, this.extension, this.import)
       : super(customClass);
+}
+
+class I18nFeature {
+  I18nFeature({required this.name, this.path});
+
+  final String name;
+  final String? path;
 }

--- a/lib/src/model/resources.dart
+++ b/lib/src/model/resources.dart
@@ -4,7 +4,7 @@ class Resources {
   final List<String> fonts;
   final Assets assets;
   final I18nLocales? i18n;
-  final Map<String, I18nLocales>? i18nFeatures;
+  final List<I18nFeature>? i18nFeatures;
 
   Resources({
     required this.fonts,
@@ -84,11 +84,4 @@ class CustomAssetType extends AssetType {
 
   const CustomAssetType(this.customClass, this.extension, this.import)
       : super(customClass);
-}
-
-class I18nFeature {
-  I18nFeature({required this.name, this.path});
-
-  final String name;
-  final String? path;
 }

--- a/lib/src/parser/i18n/i18n_parser.dart
+++ b/lib/src/parser/i18n/i18n_parser.dart
@@ -60,10 +60,7 @@ Map<String, I18nLocales>? parseFeatureStrings(
   final result = <String, I18nLocales>{};
 
   for (final feature in features) {
-    final directory = feature.path != null
-        ? Directory(feature.path!).path
-        : join(dirname(defaultIntlFile), feature.name);
-
+    final directory = getDirectoryForFeature(feature, defaultIntlFile);
     final locales = parseStrings(join(directory, defaultFilename));
 
     if (locales != null) {
@@ -72,6 +69,12 @@ Map<String, I18nLocales>? parseFeatureStrings(
   }
 
   return result;
+}
+
+String getDirectoryForFeature(I18nFeature feature, String defaultIntlFile) {
+  return feature.path != null
+      ? Directory(feature.path!).path
+      : join(dirname(defaultIntlFile), feature.name);
 }
 
 Locale? _localeFromFileName(File file) {

--- a/lib/src/parser/i18n/i18n_parser.dart
+++ b/lib/src/parser/i18n/i18n_parser.dart
@@ -1,9 +1,10 @@
 import 'dart:io';
 
 import 'package:collection/collection.dart';
-import 'package:r_flutter/src/model/i18n.dart';
-import 'package:r_flutter/src/parser/i18n/arb_parser.dart';
 import 'package:path/path.dart';
+import 'package:r_flutter/src/model/i18n.dart';
+import 'package:r_flutter/src/model/resources.dart';
+import 'package:r_flutter/src/parser/i18n/arb_parser.dart';
 
 I18nLocales? parseStrings(String? defaultIntlFile) {
   if (defaultIntlFile == null || defaultIntlFile.isEmpty) {
@@ -43,10 +44,40 @@ I18nLocales? parseStrings(String? defaultIntlFile) {
   return I18nLocales(defaultLocale, locales);
 }
 
+Map<String, I18nLocales>? parseFeatureStrings(
+  String? defaultIntlFile,
+  List<I18nFeature> features,
+) {
+  if (defaultIntlFile == null || defaultIntlFile.isEmpty) {
+    return null;
+  }
+
+  if (features.isEmpty) {
+    return null;
+  }
+
+  final defaultFilename = basename(defaultIntlFile);
+  final result = <String, I18nLocales>{};
+
+  for (final feature in features) {
+    final directory = feature.path != null
+        ? Directory(feature.path!).path
+        : join(dirname(defaultIntlFile), feature.name);
+
+    final locales = parseStrings(join(directory, defaultFilename));
+
+    if (locales != null) {
+      result.putIfAbsent(feature.name, () => locales);
+    }
+  }
+
+  return result;
+}
+
 Locale? _localeFromFileName(File file) {
   final name = basenameWithoutExtension(file.path);
   if (RegExp(r'^[a-z]{2}$').hasMatch(name)) {
-    return Locale(name, null);
+    return Locale(name);
   }
   if (RegExp(r'^[a-z]{2}_[A-Z]{2}$').hasMatch(name)) {
     final localeParts = name.split("_");
@@ -72,6 +103,7 @@ Locale? _localeFromFileName(File file) {
 
 abstract class I18nParser {
   bool supportsFile(File file);
+
   List<I18nString> parseFile(File file);
 
   static List<I18nParser> all() {

--- a/test/config_test.dart
+++ b/test/config_test.dart
@@ -10,7 +10,7 @@ void main() {
     expect(config.assetClasses, []);
     expect(config.ignoreAssets, []);
     expect(config.intlFilename, isNull);
-    expect(config.i18nFeatures, []);
+    expect(config.i18nFeatures, {});
   });
 
   test("test parse asset classes to config", () {
@@ -29,7 +29,7 @@ r_flutter:
     expect(config.assetClasses[0].customClass, "SvgFile");
     expect(config.ignoreAssets, []);
     expect(config.intlFilename, isNull);
-    expect(config.i18nFeatures, []);
+    expect(config.i18nFeatures, {});
   });
 
   test("test parse multiple asset classes to config", () {
@@ -61,7 +61,7 @@ r_flutter:
 
     expect(config.ignoreAssets, []);
     expect(config.intlFilename, isNull);
-    expect(config.i18nFeatures, []);
+    expect(config.i18nFeatures, {});
   });
 
   test("test parse intl file to config", () {
@@ -74,7 +74,7 @@ r_flutter:
     expect(config.assetClasses, []);
     expect(config.ignoreAssets, []);
     expect(config.intlFilename, "lib/i18n/en.arb");
-    expect(config.i18nFeatures, []);
+    expect(config.i18nFeatures, {});
   });
 
   test("test parse ignored assets to config", () {
@@ -93,7 +93,7 @@ r_flutter:
       ["lib/assets/sub/ignore1", "lib/assets/sub/ignore2", "lib/i18n"],
     );
     expect(config.intlFilename, isNull);
-    expect(config.i18nFeatures, []);
+    expect(config.i18nFeatures, {});
   });
 
   test("test combined config to config", () {
@@ -132,9 +132,9 @@ r_flutter:
     expect(config.ignoreAssets, []);
     expect(config.intlFilename, "lib/i18n/en.arb");
     expect(config.i18nFeatures, hasLength(2));
-    expect(config.i18nFeatures[0].name, 'home');
-    expect(config.i18nFeatures[0].path, 'lib/i18n/custom/home/');
-    expect(config.i18nFeatures[1].name, 'profile');
-    expect(config.i18nFeatures[1].path, isNull);
+    expect(config.i18nFeatures.containsKey('home'), true);
+    expect(config.i18nFeatures['home'], 'lib/i18n/custom/home/');
+    expect(config.i18nFeatures.containsKey('profile'), true);
+    expect(config.i18nFeatures['profile'], isNull);
   });
 }

--- a/test/config_test.dart
+++ b/test/config_test.dart
@@ -4,7 +4,7 @@ import 'package:yaml/yaml.dart';
 
 void main() {
   test("test parse empty yaml to config", () {
-    final config = Config.parsePubspecConfig(YamlMap());
+    final config = Config.fromPubspec(YamlMap());
     expect(config, isNotNull);
     expect(config.pubspecFilename, "pubspec.yaml");
     expect(config.assetClasses, []);
@@ -13,7 +13,7 @@ void main() {
   });
 
   test("test parse asset classes to config", () {
-    final config = Config.parsePubspecConfig(loadYaml("""
+    final config = Config.fromPubspec(loadYaml("""
 r_flutter:
   asset_classes:
     ".svg": 
@@ -31,7 +31,7 @@ r_flutter:
   });
 
   test("test parse multiple asset classes to config", () {
-    final config = Config.parsePubspecConfig(loadYaml("""
+    final config = Config.fromPubspec(loadYaml("""
 r_flutter:
   asset_classes:
     ".svg": 
@@ -61,7 +61,7 @@ r_flutter:
     expect(config.intlFilename, isNull);
   });
   test("test parse intl file to config", () {
-    final config = Config.parsePubspecConfig(loadYaml("""
+    final config = Config.fromPubspec(loadYaml("""
 r_flutter:
   intl: lib/i18n/en.arb
     """) as YamlMap);
@@ -73,7 +73,7 @@ r_flutter:
   });
 
   test("test parse ignored assets to config", () {
-    final config = Config.parsePubspecConfig(loadYaml("""
+    final config = Config.fromPubspec(loadYaml("""
 r_flutter:
   ignore:
     - lib/assets/sub/ignore1
@@ -83,13 +83,15 @@ r_flutter:
     expect(config, isNotNull);
     expect(config.pubspecFilename, "pubspec.yaml");
     expect(config.assetClasses, []);
-    expect(config.ignoreAssets,
-        ["lib/assets/sub/ignore1", "lib/assets/sub/ignore2", "lib/i18n"]);
+    expect(
+      config.ignoreAssets,
+      ["lib/assets/sub/ignore1", "lib/assets/sub/ignore2", "lib/i18n"],
+    );
     expect(config.intlFilename, isNull);
   });
 
   test("test combined config to config", () {
-    final config = Config.parsePubspecConfig(loadYaml("""
+    final config = Config.fromPubspec(loadYaml("""
 r_flutter:
   asset_classes:
     ".svg": SvgFile

--- a/test/config_test.dart
+++ b/test/config_test.dart
@@ -10,6 +10,7 @@ void main() {
     expect(config.assetClasses, []);
     expect(config.ignoreAssets, []);
     expect(config.intlFilename, isNull);
+    expect(config.i18nFeatures, []);
   });
 
   test("test parse asset classes to config", () {
@@ -28,6 +29,7 @@ r_flutter:
     expect(config.assetClasses[0].customClass, "SvgFile");
     expect(config.ignoreAssets, []);
     expect(config.intlFilename, isNull);
+    expect(config.i18nFeatures, []);
   });
 
   test("test parse multiple asset classes to config", () {
@@ -59,7 +61,9 @@ r_flutter:
 
     expect(config.ignoreAssets, []);
     expect(config.intlFilename, isNull);
+    expect(config.i18nFeatures, []);
   });
+
   test("test parse intl file to config", () {
     final config = Config.fromPubspec(loadYaml("""
 r_flutter:
@@ -70,6 +74,7 @@ r_flutter:
     expect(config.assetClasses, []);
     expect(config.ignoreAssets, []);
     expect(config.intlFilename, "lib/i18n/en.arb");
+    expect(config.i18nFeatures, []);
   });
 
   test("test parse ignored assets to config", () {
@@ -88,6 +93,7 @@ r_flutter:
       ["lib/assets/sub/ignore1", "lib/assets/sub/ignore2", "lib/i18n"],
     );
     expect(config.intlFilename, isNull);
+    expect(config.i18nFeatures, []);
   });
 
   test("test combined config to config", () {
@@ -109,5 +115,26 @@ r_flutter:
 
     expect(config.ignoreAssets, ["lib/i18n"]);
     expect(config.intlFilename, "lib/de.arb");
+  });
+
+  test("test parse intl_features to config", () {
+    final config = Config.fromPubspec(loadYaml("""
+r_flutter:
+  intl: lib/i18n/en.arb
+  intl_features:
+    - name: home
+      path: lib/i18n/custom/home/
+    - name: profile
+    """) as YamlMap);
+    expect(config, isNotNull);
+    expect(config.pubspecFilename, "pubspec.yaml");
+    expect(config.assetClasses, []);
+    expect(config.ignoreAssets, []);
+    expect(config.intlFilename, "lib/i18n/en.arb");
+    expect(config.i18nFeatures, hasLength(2));
+    expect(config.i18nFeatures[0].name, 'home');
+    expect(config.i18nFeatures[0].path, 'lib/i18n/custom/home/');
+    expect(config.i18nFeatures[1].name, 'profile');
+    expect(config.i18nFeatures[1].path, isNull);
   });
 }

--- a/test/generator/i18n/i18n_generator_test.dart
+++ b/test/generator/i18n/i18n_generator_test.dart
@@ -237,7 +237,19 @@ void main() {
   });
 
   test("test i18n generation with features", () {
-    final generatedClass = generateI18nClass(testData, ['home', 'profile']);
+    final generatedClass = generateI18nClass(
+      testData,
+      [
+        I18nFeature(
+          name: 'home',
+          locales: I18nLocales(Locale('de'), []),
+        ),
+        I18nFeature(
+          name: 'profile',
+          locales: I18nLocales(Locale('de'), []),
+        ),
+      ],
+    );
     expect(generatedClass.imports, []);
     expect(generatedClass.code, """class I18n {
   final I18nLookup _lookup;
@@ -435,7 +447,12 @@ void main() {
   });
 
   test("test i18n generation for a feature", () {
-    final generatedClass = generateI18nFeatureClass(testData, 'home');
+    final generatedClass = generateI18nFeatureClass(
+      I18nFeature(
+        name: 'home',
+        locales: testData,
+      ),
+    );
     expect(generatedClass.imports, []);
     expect(generatedClass.code, """class I18nHome {
   I18nHome(this._lookup);

--- a/test/generator/i18n/i18n_generator_test.dart
+++ b/test/generator/i18n/i18n_generator_test.dart
@@ -235,4 +235,378 @@ void main() {
 }
 """);
   });
+
+  test("test i18n generation with features", () {
+    final generatedClass = generateI18nClass(testData, ['home', 'profile']);
+    expect(generatedClass.imports, []);
+    expect(generatedClass.code, """class I18n {
+  final I18nLookup _lookup;
+
+  I18n(this._lookup)
+      : home = I18nHome(_lookup.createHomeLookup()),
+        profile = I18nProfile(_lookup.createProfileLookup());
+
+  static Locale? _locale;
+
+  static Locale? get currentLocale => _locale;
+
+  /// add custom locale lookup which will be called first
+  static I18nLookup? customLookup;
+
+  static const I18nDelegate delegate = I18nDelegate();
+
+  static I18n of(BuildContext context) => Localizations.of<I18n>(context, I18n)!;
+
+  static List<Locale> get supportedLocales {
+    return const <Locale>[
+      Locale("en"),
+      Locale("de"),
+      Locale("pl")
+    ];
+  }
+
+  final I18nHome home;
+
+  final I18nProfile profile;
+
+  ///
+  /// <table style="width:100%">
+  ///   <tr>
+  ///     <th>Locale</th>
+  ///     <th>Translation</th>
+  ///   </tr>
+  ///   <tr>
+  ///     <td style="width:60px;">en</td>
+  ///     <td>"value_KEY_1"</td>
+  ///   </tr>
+  ///   <tr>
+  ///     <td style="width:60px;">de</td>
+  ///     <td><font color="yellow">⚠</font></td>
+  ///   </tr>
+  ///   <tr>
+  ///     <td style="width:60px;">pl</td>
+  ///     <td>"pl_value_KEY_1"</td>
+  ///   </tr>
+  ///  </table>
+  ///
+  String get key_1 {
+    return customLookup?.key_1 ?? _lookup.key_1;
+  }
+
+  ///
+  /// <table style="width:100%">
+  ///   <tr>
+  ///     <th>Locale</th>
+  ///     <th>Translation</th>
+  ///   </tr>
+  ///   <tr>
+  ///     <td style="width:60px;">en</td>
+  ///     <td>"value_KEY_2"</td>
+  ///   </tr>
+  ///   <tr>
+  ///     <td style="width:60px;">de</td>
+  ///     <td>"DE value_KEY_2"</td>
+  ///   </tr>
+  ///   <tr>
+  ///     <td style="width:60px;">pl</td>
+  ///     <td>"pl_value_KEY_2"</td>
+  ///   </tr>
+  ///  </table>
+  ///
+  String get key_2 {
+    return customLookup?.key_2 ?? _lookup.key_2;
+  }
+
+  ///
+  /// <table style="width:100%">
+  ///   <tr>
+  ///     <th>Locale</th>
+  ///     <th>Translation</th>
+  ///   </tr>
+  ///   <tr>
+  ///     <td style="width:60px;">en</td>
+  ///     <td>"value_KEY_3 {p1}"</td>
+  ///   </tr>
+  ///   <tr>
+  ///     <td style="width:60px;">de</td>
+  ///     <td>"DE value_KEY_3"</td>
+  ///   </tr>
+  ///   <tr>
+  ///     <td style="width:60px;">pl</td>
+  ///     <td><font color="yellow">⚠</font></td>
+  ///   </tr>
+  ///  </table>
+  ///
+  String key_3(String p1) {
+    return customLookup?.key_3(p1) ?? _lookup.key_3(p1);
+  }
+
+  ///
+  /// <table style="width:100%">
+  ///   <tr>
+  ///     <th>Locale</th>
+  ///     <th>Translation</th>
+  ///   </tr>
+  ///   <tr>
+  ///     <td style="width:60px;">en</td>
+  ///     <td>"value_KEY_4 {p1} {p2} {p3}"</td>
+  ///   </tr>
+  ///   <tr>
+  ///     <td style="width:60px;">de</td>
+  ///     <td><font color="yellow">⚠</font></td>
+  ///   </tr>
+  ///   <tr>
+  ///     <td style="width:60px;">pl</td>
+  ///     <td><font color="yellow">⚠</font></td>
+  ///   </tr>
+  ///  </table>
+  ///
+  String key_4(String p1, String p2, String p3) {
+    return customLookup?.key_4(p1, p2, p3) ?? _lookup.key_4(p1, p2, p3);
+  }
+
+  ///
+  /// <table style="width:100%">
+  ///   <tr>
+  ///     <th>Locale</th>
+  ///     <th>Translation</th>
+  ///   </tr>
+  ///   <tr>
+  ///     <td style="width:60px;">en</td>
+  ///     <td>"value_KEY_5 {p1}, {p1}, {p2}, {p3}"</td>
+  ///   </tr>
+  ///   <tr>
+  ///     <td style="width:60px;">de</td>
+  ///     <td><font color="yellow">⚠</font></td>
+  ///   </tr>
+  ///   <tr>
+  ///     <td style="width:60px;">pl</td>
+  ///     <td><font color="yellow">⚠</font></td>
+  ///   </tr>
+  ///  </table>
+  ///
+  String key_5(String p1, String p2, String p3) {
+    return customLookup?.key_5(p1, p2, p3) ?? _lookup.key_5(p1, p2, p3);
+  }
+
+  ///
+  /// <table style="width:100%">
+  ///   <tr>
+  ///     <th>Locale</th>
+  ///     <th>Translation</th>
+  ///   </tr>
+  ///   <tr>
+  ///     <td style="width:60px;">en</td>
+  ///     <td>"value_KEY_5 {p1}, {p1}, {p2}, {p3}"</td>
+  ///   </tr>
+  ///   <tr>
+  ///     <td style="width:60px;">de</td>
+  ///     <td><font color="yellow">⚠</font></td>
+  ///   </tr>
+  ///   <tr>
+  ///     <td style="width:60px;">pl</td>
+  ///     <td><font color="yellow">⚠</font></td>
+  ///   </tr>
+  ///  </table>
+  ///
+  String key_5(String p1, String p2, String p3, String p4) {
+    return customLookup?.key_5(p1, p2, p3, p4) ?? _lookup.key_5(p1, p2, p3, p4);
+  }
+
+  String? getString(String key, [Map<String, String>? placeholders]) {
+    switch (key) {
+      case I18nKeys.key_1:
+        return key_1;
+      case I18nKeys.key_2:
+        return key_2;
+      case I18nKeys.key_3:
+        return key_3(placeholders?["p1"] ?? "");
+      case I18nKeys.key_4:
+        return key_4(placeholders?["p1"] ?? "", placeholders?["p2"] ?? "", placeholders?["p3"] ?? "");
+      case I18nKeys.key_5:
+        return key_5(placeholders?["p1"] ?? "", placeholders?["p2"] ?? "", placeholders?["p3"] ?? "");
+      case I18nKeys.key_5:
+        return key_5(placeholders?["p1"] ?? "", placeholders?["p2"] ?? "", placeholders?["p3"] ?? "", placeholders?["p4"] ?? "");
+    }
+    return null;
+  }
+}
+""");
+  });
+
+  test("test i18n generation for a feature", () {
+    final generatedClass = generateI18nFeatureClass(testData, 'home');
+    expect(generatedClass.imports, []);
+    expect(generatedClass.code, """class I18nHome {
+  I18nHome(this._lookup);
+
+  final I18nHomeLookup _lookup;
+
+  /// add custom locale lookup which will be called first
+  static I18nHomeLookup? customLookup;
+
+  ///
+  /// <table style="width:100%">
+  ///   <tr>
+  ///     <th>Locale</th>
+  ///     <th>Translation</th>
+  ///   </tr>
+  ///   <tr>
+  ///     <td style="width:60px;">en</td>
+  ///     <td>"value_KEY_1"</td>
+  ///   </tr>
+  ///   <tr>
+  ///     <td style="width:60px;">de</td>
+  ///     <td><font color="yellow">⚠</font></td>
+  ///   </tr>
+  ///   <tr>
+  ///     <td style="width:60px;">pl</td>
+  ///     <td>"pl_value_KEY_1"</td>
+  ///   </tr>
+  ///  </table>
+  ///
+  String get key_1 {
+    return customLookup?.key_1 ?? _lookup.key_1;
+  }
+
+  ///
+  /// <table style="width:100%">
+  ///   <tr>
+  ///     <th>Locale</th>
+  ///     <th>Translation</th>
+  ///   </tr>
+  ///   <tr>
+  ///     <td style="width:60px;">en</td>
+  ///     <td>"value_KEY_2"</td>
+  ///   </tr>
+  ///   <tr>
+  ///     <td style="width:60px;">de</td>
+  ///     <td>"DE value_KEY_2"</td>
+  ///   </tr>
+  ///   <tr>
+  ///     <td style="width:60px;">pl</td>
+  ///     <td>"pl_value_KEY_2"</td>
+  ///   </tr>
+  ///  </table>
+  ///
+  String get key_2 {
+    return customLookup?.key_2 ?? _lookup.key_2;
+  }
+
+  ///
+  /// <table style="width:100%">
+  ///   <tr>
+  ///     <th>Locale</th>
+  ///     <th>Translation</th>
+  ///   </tr>
+  ///   <tr>
+  ///     <td style="width:60px;">en</td>
+  ///     <td>"value_KEY_3 {p1}"</td>
+  ///   </tr>
+  ///   <tr>
+  ///     <td style="width:60px;">de</td>
+  ///     <td>"DE value_KEY_3"</td>
+  ///   </tr>
+  ///   <tr>
+  ///     <td style="width:60px;">pl</td>
+  ///     <td><font color="yellow">⚠</font></td>
+  ///   </tr>
+  ///  </table>
+  ///
+  String key_3(String p1) {
+    return customLookup?.key_3(p1) ?? _lookup.key_3(p1);
+  }
+
+  ///
+  /// <table style="width:100%">
+  ///   <tr>
+  ///     <th>Locale</th>
+  ///     <th>Translation</th>
+  ///   </tr>
+  ///   <tr>
+  ///     <td style="width:60px;">en</td>
+  ///     <td>"value_KEY_4 {p1} {p2} {p3}"</td>
+  ///   </tr>
+  ///   <tr>
+  ///     <td style="width:60px;">de</td>
+  ///     <td><font color="yellow">⚠</font></td>
+  ///   </tr>
+  ///   <tr>
+  ///     <td style="width:60px;">pl</td>
+  ///     <td><font color="yellow">⚠</font></td>
+  ///   </tr>
+  ///  </table>
+  ///
+  String key_4(String p1, String p2, String p3) {
+    return customLookup?.key_4(p1, p2, p3) ?? _lookup.key_4(p1, p2, p3);
+  }
+
+  ///
+  /// <table style="width:100%">
+  ///   <tr>
+  ///     <th>Locale</th>
+  ///     <th>Translation</th>
+  ///   </tr>
+  ///   <tr>
+  ///     <td style="width:60px;">en</td>
+  ///     <td>"value_KEY_5 {p1}, {p1}, {p2}, {p3}"</td>
+  ///   </tr>
+  ///   <tr>
+  ///     <td style="width:60px;">de</td>
+  ///     <td><font color="yellow">⚠</font></td>
+  ///   </tr>
+  ///   <tr>
+  ///     <td style="width:60px;">pl</td>
+  ///     <td><font color="yellow">⚠</font></td>
+  ///   </tr>
+  ///  </table>
+  ///
+  String key_5(String p1, String p2, String p3) {
+    return customLookup?.key_5(p1, p2, p3) ?? _lookup.key_5(p1, p2, p3);
+  }
+
+  ///
+  /// <table style="width:100%">
+  ///   <tr>
+  ///     <th>Locale</th>
+  ///     <th>Translation</th>
+  ///   </tr>
+  ///   <tr>
+  ///     <td style="width:60px;">en</td>
+  ///     <td>"value_KEY_5 {p1}, {p1}, {p2}, {p3}"</td>
+  ///   </tr>
+  ///   <tr>
+  ///     <td style="width:60px;">de</td>
+  ///     <td><font color="yellow">⚠</font></td>
+  ///   </tr>
+  ///   <tr>
+  ///     <td style="width:60px;">pl</td>
+  ///     <td><font color="yellow">⚠</font></td>
+  ///   </tr>
+  ///  </table>
+  ///
+  String key_5(String p1, String p2, String p3, String p4) {
+    return customLookup?.key_5(p1, p2, p3, p4) ?? _lookup.key_5(p1, p2, p3, p4);
+  }
+
+  String? getString(String key, [Map<String, String>? placeholders]) {
+    switch (key) {
+      case I18nHomeKeys.key_1:
+        return key_1;
+      case I18nHomeKeys.key_2:
+        return key_2;
+      case I18nHomeKeys.key_3:
+        return key_3(placeholders?["p1"] ?? "");
+      case I18nHomeKeys.key_4:
+        return key_4(placeholders?["p1"] ?? "", placeholders?["p2"] ?? "", placeholders?["p3"] ?? "");
+      case I18nHomeKeys.key_5:
+        return key_5(placeholders?["p1"] ?? "", placeholders?["p2"] ?? "", placeholders?["p3"] ?? "");
+      case I18nHomeKeys.key_5:
+        return key_5(placeholders?["p1"] ?? "", placeholders?["p2"] ?? "", placeholders?["p3"] ?? "", placeholders?["p4"] ?? "");
+    }
+    return null;
+  }
+}
+""");
+  });
 }

--- a/test/generator/i18n/keys_generator_test.dart
+++ b/test/generator/i18n/keys_generator_test.dart
@@ -3,16 +3,16 @@ import 'package:r_flutter/src/model/i18n.dart';
 import 'package:test/test.dart';
 
 void main() {
-  test("test generateI18nKeysClass", () {
-    final testData = I18nLocales(Locale("en", null), [
-      I18nLocale(Locale("en", null), [
+  test("test generateI18nKeysClasses", () {
+    final testData = I18nLocales(Locale("en"), [
+      I18nLocale(Locale("en"), [
         I18nString(key: "key_1", value: "must_be_not_null"),
         I18nString(key: "key.2", value: "must_be_not_null"),
         I18nString(
             key: "key_3", value: "must_be_not_null", placeholders: ["name"]),
       ])
     ]);
-    final resultClass = generateI18nKeysClass(testData);
+    final resultClass = generateI18nKeysClasses(testData).first;
     expect(resultClass.imports, []);
     expect(resultClass.code, """class I18nKeys {
   static const String key_1 = "key_1";

--- a/test/generator/i18n/lookup_generator_test.dart
+++ b/test/generator/i18n/lookup_generator_test.dart
@@ -133,6 +133,68 @@ void main() {
 """);
   });
 
+  test("test default lookup with features", () {
+    final lookupClass = generateDefaultLookupClass(
+      testData,
+      testData.locales[0],
+      features: ['home', 'profile'],
+    );
+    expect(lookupClass.imports, []);
+    expect(lookupClass.code, """class I18nLookup {
+  String getString(String key, [Map<String, String>? placeholders]) {
+    throw UnimplementedError("I18nLookup.getString");
+  }
+
+  String get key_1 {
+    return getString(I18nKeys.key_1);
+  }
+
+  String get key_2 {
+    return getString(I18nKeys.key_2);
+  }
+
+  String key_3(String p1) {
+    return getString(I18nKeys.key_3, {"p1": p1});
+  }
+
+  String key_4(String p1, String p2, String p3) {
+    return getString(I18nKeys.key_4, {"p1": p1, "p2": p2, "p3": p3});
+  }
+
+  String key_5(String p1, String p2, String p3) {
+    return getString(I18nKeys.key_5, {"p1": p1, "p2": p2, "p3": p3});
+  }
+
+  String key_5(String p1, String p2, String p3, String p4) {
+    return getString(I18nKeys.key_5, {"p1": p1, "p2": p2, "p3": p3, "p4": p4});
+  }
+
+  I18nHomeLookup createHomeLookup() => I18nHomeLookup();
+
+  I18nProfileLookup createProfileLookup() => I18nProfileLookup();
+}
+""");
+  });
+
+  test("test default lookup for a feature", () {
+    final lookupClass = generateDefaultLookupClass(
+      testData,
+      testData.locales.firstWhere((it) => it.locale == Locale("ko")),
+      featureName: 'home',
+    );
+    expect(lookupClass.imports, []);
+    expect(lookupClass.code, """class I18nHomeLookup {
+  String getString(String key, [Map<String, String>? placeholders]) {
+    throw UnimplementedError("I18nHomeLookup.getString");
+  }
+
+  String get key_1 {
+    return getString(I18nHomeKeys.key_1);
+  }
+}
+""");
+  });
+
   test("test additional keys in none default locales are ignored", () {
     final lookupClass = generateLookupClass(
       testData,
@@ -235,6 +297,45 @@ void main() {
   @override
   String get key_1 {
     return "value_zh_Hans";
+  }
+}
+""");
+  });
+
+  test("test locale with features", () {
+    final lookupClass = generateLookupClass(
+      testData,
+      testData.locales.firstWhere((it) => it.locale == Locale("ko")),
+      features: ['home', 'profile'],
+    );
+    expect(lookupClass.imports, []);
+    expect(lookupClass.code, """class I18nLookup_ko extends I18nLookup_en {
+  @override
+  String get key_1 {
+    return "value_ko";
+  }
+
+  @override
+  I18nHomeLookup_ko createHomeLookup() => I18nHomeLookup_ko();
+
+  @override
+  I18nProfileLookup_ko createProfileLookup() => I18nProfileLookup_ko();
+}
+""");
+  });
+
+  test("test locale for a feature", () {
+    final lookupClass = generateLookupClass(
+      testData,
+      testData.locales.firstWhere((it) => it.locale == Locale("ko")),
+      featureName: 'home',
+    );
+    expect(lookupClass.imports, []);
+    expect(
+        lookupClass.code, """class I18nHomeLookup_ko extends I18nHomeLookup_en {
+  @override
+  String get key_1 {
+    return "value_ko";
   }
 }
 """);

--- a/test/generator/i18n/lookup_generator_test.dart
+++ b/test/generator/i18n/lookup_generator_test.dart
@@ -65,9 +65,9 @@ void main() {
 
   test("test secondary language", () {
     final lookupClass = generateLookupClass(
-        i18n: testData,
-        value: testData.locales.firstWhere((it) => it.locale == Locale("pl")),
-        isDefaultClass: false);
+      testData,
+      testData.locales.firstWhere((it) => it.locale == Locale("pl")),
+    );
     expect(lookupClass.imports, []);
     expect(lookupClass.code, """class I18nLookup_pl extends I18nLookup_en {
   @override
@@ -82,9 +82,9 @@ void main() {
       "test secondary language with different placeholder list. should take values from default locale",
       () {
     final lookupClass = generateLookupClass(
-        i18n: testData,
-        value: testData.locales.firstWhere((it) => it.locale == Locale("de")),
-        isDefaultClass: false);
+      testData,
+      testData.locales.firstWhere((it) => it.locale == Locale("de")),
+    );
     expect(lookupClass.imports, []);
     expect(lookupClass.code, """class I18nLookup_de extends I18nLookup_en {
   @override
@@ -96,8 +96,10 @@ void main() {
   });
 
   test("test default lookup", () {
-    final lookupClass = generateLookupClass(
-        i18n: testData, value: testData.locales[0], isDefaultClass: true);
+    final lookupClass = generateDefaultLookupClass(
+      testData,
+      testData.locales[0],
+    );
     expect(lookupClass.imports, []);
     expect(lookupClass.code, """class I18nLookup {
   String getString(String key, [Map<String, String>? placeholders]) {
@@ -133,9 +135,9 @@ void main() {
 
   test("test additional keys in none default locales are ignored", () {
     final lookupClass = generateLookupClass(
-        i18n: testData,
-        value: testData.locales.firstWhere((it) => it.locale == Locale("ru")),
-        isDefaultClass: false);
+      testData,
+      testData.locales.firstWhere((it) => it.locale == Locale("ru")),
+    );
     expect(lookupClass.imports, []);
     expect(lookupClass.code, """class I18nLookup_ru extends I18nLookup_en {
 }
@@ -144,9 +146,9 @@ void main() {
 
   test("test additional keys in none default locales are ignored 2", () {
     final lookupClass = generateLookupClass(
-        i18n: testData,
-        value: testData.locales.firstWhere((it) => it.locale == Locale("gr")),
-        isDefaultClass: false);
+      testData,
+      testData.locales.firstWhere((it) => it.locale == Locale("gr")),
+    );
     expect(lookupClass.imports, []);
     expect(lookupClass.code, """class I18nLookup_gr extends I18nLookup_en {
   @override
@@ -166,10 +168,9 @@ void main() {
       "test locale with country code overrides the same locale without country code",
       () {
     final lookupClass = generateLookupClass(
-        i18n: testData,
-        value: testData.locales
-            .firstWhere((it) => it.locale == Locale("de", "DE")),
-        isDefaultClass: false);
+      testData,
+      testData.locales.firstWhere((it) => it.locale == Locale("de", "DE")),
+    );
     expect(lookupClass.imports, []);
     expect(lookupClass.code, """class I18nLookup_de_DE extends I18nLookup_de {
   @override
@@ -182,10 +183,9 @@ void main() {
 
   test("test locale with country code without base locale support", () {
     final lookupClass = generateLookupClass(
-        i18n: testData,
-        value: testData.locales
-            .firstWhere((it) => it.locale == Locale("zh", "HK")),
-        isDefaultClass: false);
+      testData,
+      testData.locales.firstWhere((it) => it.locale == Locale("zh", "HK")),
+    );
     expect(lookupClass.imports, []);
     expect(lookupClass.code, """class I18nLookup_zh_HK extends I18nLookup_en {
   @override
@@ -200,14 +200,14 @@ void main() {
       "test locale with script code overrides the same locale without script code",
       () {
     final lookupClass = generateLookupClass(
-        i18n: testData,
-        value: testData.locales.firstWhere((it) =>
-            it.locale ==
-            Locale.fromSubtags(
-              languageCode: "ko",
-              scriptCode: "Hani",
-            )),
-        isDefaultClass: false);
+      testData,
+      testData.locales.firstWhere((it) =>
+          it.locale ==
+          Locale.fromSubtags(
+            languageCode: "ko",
+            scriptCode: "Hani",
+          )),
+    );
     expect(lookupClass.imports, []);
     expect(lookupClass.code, """class I18nLookup_ko_Hani extends I18nLookup_ko {
   @override
@@ -220,14 +220,16 @@ void main() {
 
   test("test locale with script code without base locale support", () {
     final lookupClass = generateLookupClass(
-        i18n: testData,
-        value: testData.locales.firstWhere((it) =>
+      testData,
+      testData.locales.firstWhere(
+        (it) =>
             it.locale ==
             Locale.fromSubtags(
               languageCode: "zh",
               scriptCode: "Hans",
-            )),
-        isDefaultClass: false);
+            ),
+      ),
+    );
     expect(lookupClass.imports, []);
     expect(lookupClass.code, """class I18nLookup_zh_Hans extends I18nLookup_en {
   @override

--- a/test/generator/i18n/lookup_generator_test.dart
+++ b/test/generator/i18n/lookup_generator_test.dart
@@ -137,7 +137,16 @@ void main() {
     final lookupClass = generateDefaultLookupClass(
       testData,
       testData.locales[0],
-      features: ['home', 'profile'],
+      features: [
+        I18nFeature(
+          name: 'home',
+          locales: testData,
+        ),
+        I18nFeature(
+          name: 'profile',
+          locales: testData,
+        ),
+      ],
     );
     expect(lookupClass.imports, []);
     expect(lookupClass.code, """class I18nLookup {
@@ -180,7 +189,10 @@ void main() {
     final lookupClass = generateDefaultLookupClass(
       testData,
       testData.locales.firstWhere((it) => it.locale == Locale("ko")),
-      featureName: 'home',
+      feature: I18nFeature(
+        name: 'home',
+        locales: testData,
+      ),
     );
     expect(lookupClass.imports, []);
     expect(lookupClass.code, """class I18nHomeLookup {
@@ -306,7 +318,16 @@ void main() {
     final lookupClass = generateLookupClass(
       testData,
       testData.locales.firstWhere((it) => it.locale == Locale("ko")),
-      features: ['home', 'profile'],
+      features: [
+        I18nFeature(
+          name: 'home',
+          locales: testData,
+        ),
+        I18nFeature(
+          name: 'profile',
+          locales: testData,
+        ),
+      ],
     );
     expect(lookupClass.imports, []);
     expect(lookupClass.code, """class I18nLookup_ko extends I18nLookup_en {
@@ -328,7 +349,10 @@ void main() {
     final lookupClass = generateLookupClass(
       testData,
       testData.locales.firstWhere((it) => it.locale == Locale("ko")),
-      featureName: 'home',
+      feature: I18nFeature(
+        name: 'home',
+        locales: testData,
+      ),
     );
     expect(lookupClass.imports, []);
     expect(

--- a/test/generator/i18n/lookup_generator_test.dart
+++ b/test/generator/i18n/lookup_generator_test.dart
@@ -364,4 +364,59 @@ void main() {
 }
 """);
   });
+
+  test("test feature does not support the primary locale", () {
+    final lookupClass = generateLookupClass(
+      testData,
+      I18nLocale(Locale("ro"), [
+        I18nString(key: "key_1", value: "value_KEY_1"),
+      ]),
+      features: [
+        I18nFeature(
+          name: 'home',
+          locales: I18nLocales(Locale('bg'), []),
+        )
+      ],
+    );
+    expect(lookupClass.imports, []);
+    expect(lookupClass.code, """class I18nLookup_ro extends I18nLookup_en {
+  @override
+  String get key_1 {
+    return "value_KEY_1";
+  }
+}
+""");
+  });
+
+  test("test only some features support the primary locale", () {
+    final lookupClass = generateLookupClass(
+      testData,
+      I18nLocale(Locale("ro"), [
+        I18nString(key: "key_1", value: "value_KEY_1"),
+      ]),
+      features: [
+        I18nFeature(
+          name: 'home',
+          locales: I18nLocales(Locale('bg'), []),
+        ),
+        I18nFeature(
+          name: 'profile',
+          locales: I18nLocales(Locale('en'), [
+            I18nLocale(Locale('ro'), []),
+          ]),
+        ),
+      ],
+    );
+    expect(lookupClass.imports, []);
+    expect(lookupClass.code, """class I18nLookup_ro extends I18nLookup_en {
+  @override
+  String get key_1 {
+    return "value_KEY_1";
+  }
+
+  @override
+  I18nProfileLookup_ro createProfileLookup() => I18nProfileLookup_ro();
+}
+""");
+  });
 }

--- a/test/generator/i18n/lookup_generator_test.dart
+++ b/test/generator/i18n/lookup_generator_test.dart
@@ -419,4 +419,33 @@ void main() {
 }
 """);
   });
+
+  test("test lookup for feature-only locale", () {
+    final lookupClass = generateLookupClass(
+      I18nLocales(
+        Locale('bg'),
+        [I18nLocale(Locale('bg'), [])],
+      ),
+      I18nLocale(Locale("ro"), []),
+      features: [
+        I18nFeature(
+          name: 'home',
+          locales: I18nLocales(Locale('bg'), [I18nLocale(Locale("ro"), [])]),
+        ),
+        I18nFeature(
+          name: 'profile',
+          locales: I18nLocales(Locale('en'), [
+            I18nLocale(Locale('bg'), []),
+          ]),
+        ),
+      ],
+    );
+    expect(lookupClass.imports, []);
+    expect(lookupClass.code, """class I18nLookup_ro extends I18nLookup_bg {
+
+  @override
+  I18nHomeLookup_ro createHomeLookup() => I18nHomeLookup_ro();
+}
+""");
+  });
 }


### PR DESCRIPTION
This PR adds support for organising intl strings by feature. See the README file on how to do that. This functionality is completely optional and it should keep backwards compatibility with the previous versions of r_flutter.