### PR TITLE
Change comment file path to relative instead of absolute URI

### DIFF
--- a/lib/src/generator/assets_generator.dart
+++ b/lib/src/generator/assets_generator.dart
@@ -58,17 +58,6 @@ DartClass? _generateImageAssetsClass(List<Asset> assets) {
 bool? isExample;
 
 String createComment(Asset asset) {
-  String path = asset.fileUri;
-
-  const examplePath = 'r_flutter/example/';
-
-  isExample ??= path.contains(examplePath);
-
-  // a hack to prevent commited assets.dart from changing constantly
-  if (isExample == true) {
-    path = path.substring(path.indexOf(examplePath) + examplePath.length);
-    path = 'file:///Users/user/path/$path';
-  }
-
+  final path = asset.path;
   return "  /// ![]($path)\n";
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: r_flutter
-version: 0.9.0
+version: 0.9.1
 description: Generate constants for resources which require using them as a String like fonts and assets.
 
 homepage: https://github.com/timfreiheit/r_flutter

--- a/test/generator/assets_generator_test.dart
+++ b/test/generator/assets_generator_test.dart
@@ -14,7 +14,7 @@ void main() {
     expect(result.length, 1);
     expect(result[0].imports, []);
     expect(result[0].code, """class Assets {
-  /// ![](file:///Users/user/path/lib/path/file.txt)
+  /// ![](lib/path/file.txt)
   static const String file = "lib/path/file.txt";
 }
 """);
@@ -31,7 +31,7 @@ void main() {
     expect(result.length, 1);
     expect(result[0].imports, ['package:flutter/widgets.dart']);
     expect(result[0].code, """class Images {
-  /// ![](file:///Users/user/path/lib/path/file.png)
+  /// ![](lib/path/file.png)
   static AssetImage get file => const AssetImage("lib/path/file.png");
 }
 """);
@@ -53,7 +53,7 @@ void main() {
     expect(result.length, 1);
     expect(result[0].imports, ['asset_classes.dart']);
     expect(result[0].code, """class Assets {
-  /// ![](file:///Users/user/path/lib/path/file.svg)
+  /// ![](lib/path/file.svg)
   static const SvgFile file = SvgFile("lib/path/file.svg");
 }
 """);
@@ -99,20 +99,20 @@ void main() {
     expect(result.length, 2);
     expect(result[0].imports, ['asset_classes.dart']);
     expect(result[0].code, """class Assets {
-  /// ![](file:///Users/user/path/lib/path/file.txt)
+  /// ![](lib/path/file.txt)
   static const String file = "lib/path/file.txt";
-  /// ![](file:///Users/user/path/lib/path/file.txt)
+  /// ![](lib/path/file2.txt)
   static const String file2 = "lib/path/file2.txt";
-  /// ![](file:///Users/user/path/lib/path/svgfile.svg)
+  /// ![](lib/path/svgfile.svg)
   static const SvgFile svgfile = SvgFile("lib/path/svgfile.svg");
 }
 """);
 
     expect(result[1].imports, ['package:flutter/widgets.dart']);
     expect(result[1].code, """class Images {
-  /// ![](file:///Users/user/path/lib/path/image.png)
+  /// ![](lib/path/file.png)
   static AssetImage get image => const AssetImage("lib/path/file.png");
-  /// ![](file:///Users/user/path/lib/path/image2.png)
+  /// ![](lib/path/image2.png)
   static AssetImage get image2 => const AssetImage("lib/path/image2.png");
 }
 """);


### PR DESCRIPTION
This PR replaces the absolute file path with the relative one in the comments in the `assets.dart` file. The reasoning behind this is because when working in a team, every time when a team member runs the code generation command, the `assets.dart` file will change, while the only changes in the file were the comments. ex:
This:
```
  /// ![](file:///Users/khaleel/my_app/assets/svg/img-placeholder-user1.png)
```
Would change to this:
```
  /// ![](file:///Users/ahmed/my_app/assets/svg/img-placeholder-user1.png)
```

In case of PR approved, this is the end result:
```
  /// ![](assets/svg/img-placeholder-user1.svg)
```