### PR TITLE
Add comments flag to pubspec configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,15 +22,16 @@ dev_dependencies:
 # important: this is root level option
 r_flutter:
   intl: lib/i18n/en.arb
-  add_file_path_comments: false
+  add_file_path_comments: false # default is true
   ignore:
     - lib/assets/sub/ignore1 #use ignore option to skip 
     - lib/assets/sub/ignore2
     - lib/i18n
 ```
 Options:
-- intl: Points to a localization file that would be used to generate localization keys. arb files are essentialy json files with some special, optional keys. Specifing this is optional.
-- ignore: specifies a list of files/directories that should be skipped during code generation. 
+- `intl`: Points to a localization file that would be used to generate localization keys. arb files are essentialy json files with some special, optional keys. Specifing this is optional.
+- `add_file_path_comments`: specifies wither it should print file paths comments for assets files.
+- `ignore`: specifies a list of files/directories that should be skipped during code generation. 
 
 3. Execute `flutter packages pub run build_runner build` command in your project's directory.
 Alternativly you can run `flutter pub run r_flutter:generate` to only run r_flutter without using the whole `build_runner`.

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ dev_dependencies:
 # important: this is root level option
 r_flutter:
   intl: lib/i18n/en.arb
+  add_file_path_comments: false
   ignore:
     - lib/assets/sub/ignore1 #use ignore option to skip 
     - lib/assets/sub/ignore2

--- a/lib/src/arguments.dart
+++ b/lib/src/arguments.dart
@@ -6,12 +6,14 @@ class Config {
   final String pubspecFilename;
   final List<String> ignoreAssets;
   final String? intlFilename;
+  final bool addFilePathComments;
   final List<CustomAssetType> assetClasses;
   final Map<String, String?> i18nFeatures;
 
   Config._({
     required this.pubspecFilename,
     this.intlFilename,
+    this.addFilePathComments = true,
     this.ignoreAssets = const [],
     this.assetClasses = const [],
     this.i18nFeatures = const {},
@@ -33,6 +35,9 @@ class Config {
             .cast<String>() ??
         [];
     final intlFilename = safeCast<String>(rFlutterConfig['intl']);
+
+    final addFilePathComments =
+        safeCast<bool>(rFlutterConfig['add_file_path_comments']) ?? true;
 
     final featureList = safeCast<YamlList>(rFlutterConfig['intl_features'])
             ?.map((e) => safeCast<YamlMap>(e))
@@ -73,6 +78,7 @@ class Config {
       pubspecFilename: pubspecFilename,
       ignoreAssets: ignoreAssets,
       intlFilename: intlFilename,
+      addFilePathComments: addFilePathComments,
       assetClasses: classes,
       i18nFeatures: features,
     );

--- a/lib/src/generator/assets_generator.dart
+++ b/lib/src/generator/assets_generator.dart
@@ -2,16 +2,26 @@ import 'package:r_flutter/src/generator/generator.dart';
 import 'package:r_flutter/src/model/dart_class.dart';
 import 'package:r_flutter/src/model/resources.dart';
 
-List<DartClass> generateAssetsClass(List<Asset> assets) {
+List<DartClass> generateAssetsClass(
+  List<Asset> assets, {
+  bool addFilePathComments = true,
+}) {
   return [
     _generateAssetConstantsClass(
-        assets.where((item) => item.type != AssetType.image).toList()),
+      assets.where((item) => item.type != AssetType.image).toList(),
+      addFilePathComments: addFilePathComments,
+    ),
     _generateImageAssetsClass(
-        assets.where((item) => item.type == AssetType.image).toList())
+      assets.where((item) => item.type == AssetType.image).toList(),
+      addFilePathComments: addFilePathComments,
+    )
   ].where((it) => it != null).toList().cast<DartClass>();
 }
 
-DartClass? _generateAssetConstantsClass(List<Asset> assets) {
+DartClass? _generateAssetConstantsClass(
+  List<Asset> assets, {
+  required bool addFilePathComments,
+}) {
   if (assets.isEmpty) {
     return null;
   }
@@ -20,7 +30,9 @@ DartClass? _generateAssetConstantsClass(List<Asset> assets) {
 
   final classString = StringBuffer("class Assets {\n");
   for (final asset in assets) {
-    classString.write(createComment(asset));
+    if (addFilePathComments) {
+      classString.write(createComment(asset));
+    }
 
     final type = asset.type;
     if (type is CustomAssetType) {
@@ -38,13 +50,18 @@ DartClass? _generateAssetConstantsClass(List<Asset> assets) {
       code: classString.toString(), imports: imports.toList()..sort());
 }
 
-DartClass? _generateImageAssetsClass(List<Asset> assets) {
+DartClass? _generateImageAssetsClass(
+  List<Asset> assets, {
+  required bool addFilePathComments,
+}) {
   if (assets.isEmpty) {
     return null;
   }
   final classString = StringBuffer("class Images {\n");
   for (final asset in assets) {
-    classString.write(createComment(asset));
+    if (addFilePathComments) {
+      classString.write(createComment(asset));
+    }
     classString.writeln(
         "  static AssetImage get ${createVariableName(asset.name)} => const AssetImage(\"${asset.path}\");");
   }

--- a/lib/src/generator/generator.dart
+++ b/lib/src/generator/generator.dart
@@ -16,7 +16,10 @@ String generateFile(Resources res, Config arguments) {
   if (fontClass != null) {
     classes.add(fontClass);
   }
-  classes.addAll(generateAssetsClass(res.assets.assets));
+  classes.addAll(generateAssetsClass(
+    res.assets.assets,
+    addFilePathComments: arguments.addFilePathComments,
+  ));
 
   final fullCode = StringBuffer("");
   final imports = classes.expand((it) => it.imports).toSet().toList();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: r_flutter
-version: 0.9.0
+version: 0.9.1
 description: Generate constants for resources which require using them as a String like fonts and assets.
 
 homepage: https://github.com/timfreiheit/r_flutter

--- a/test/config_test.dart
+++ b/test/config_test.dart
@@ -11,6 +11,7 @@ void main() {
     expect(config.ignoreAssets, []);
     expect(config.intlFilename, isNull);
     expect(config.i18nFeatures, {});
+    expect(config.addFilePathComments, true);
   });
 
   test("test parse asset classes to config", () {
@@ -30,6 +31,7 @@ r_flutter:
     expect(config.ignoreAssets, []);
     expect(config.intlFilename, isNull);
     expect(config.i18nFeatures, {});
+    expect(config.addFilePathComments, true);
   });
 
   test("test parse multiple asset classes to config", () {
@@ -62,6 +64,7 @@ r_flutter:
     expect(config.ignoreAssets, []);
     expect(config.intlFilename, isNull);
     expect(config.i18nFeatures, {});
+    expect(config.addFilePathComments, true);
   });
 
   test("test parse intl file to config", () {
@@ -75,6 +78,7 @@ r_flutter:
     expect(config.ignoreAssets, []);
     expect(config.intlFilename, "lib/i18n/en.arb");
     expect(config.i18nFeatures, {});
+    expect(config.addFilePathComments, true);
   });
 
   test("test parse ignored assets to config", () {
@@ -94,6 +98,7 @@ r_flutter:
     );
     expect(config.intlFilename, isNull);
     expect(config.i18nFeatures, {});
+    expect(config.addFilePathComments, true);
   });
 
   test("test combined config to config", () {
@@ -115,6 +120,7 @@ r_flutter:
 
     expect(config.ignoreAssets, ["lib/i18n"]);
     expect(config.intlFilename, "lib/de.arb");
+    expect(config.addFilePathComments, true);
   });
 
   test("test parse intl_features to config", () {
@@ -136,5 +142,20 @@ r_flutter:
     expect(config.i18nFeatures['home'], 'lib/i18n/custom/home/');
     expect(config.i18nFeatures.containsKey('profile'), true);
     expect(config.i18nFeatures['profile'], isNull);
+    expect(config.addFilePathComments, true);
+  });
+
+  test("test parse add_file_path_comments to config", () {
+    final config = Config.fromPubspec(loadYaml("""
+r_flutter:
+  add_file_path_comments: false
+    """) as YamlMap);
+    expect(config, isNotNull);
+    expect(config.pubspecFilename, "pubspec.yaml");
+    expect(config.assetClasses, []);
+    expect(config.ignoreAssets, []);
+    expect(config.intlFilename, isNull);
+    expect(config.i18nFeatures, {});
+    expect(config.addFilePathComments, false);
   });
 }

--- a/test/generator/assets_generator_test.dart
+++ b/test/generator/assets_generator_test.dart
@@ -137,6 +137,25 @@ void main() {
 """);
   });
 
+  test("test single simple image asset without file path comments", () {
+    final result = generateAssetsClass(
+      [
+        Asset(
+            name: "file",
+            path: "lib/path/file.png",
+            fileUri: "file:///Users/user/path/lib/path/file.png",
+            type: AssetType.image)
+      ],
+      addFilePathComments: false,
+    );
+    expect(result.length, 1);
+    expect(result[0].imports, ['package:flutter/widgets.dart']);
+    expect(result[0].code, """class Images {
+  static AssetImage get file => const AssetImage("lib/path/file.png");
+}
+""");
+  });
+
   test("test multiple simple assets without file path comments", () {
     final result = generateAssetsClass(
       [

--- a/test/generator/assets_generator_test.dart
+++ b/test/generator/assets_generator_test.dart
@@ -117,4 +117,80 @@ void main() {
 }
 """);
   });
+
+  test("test single simple asset without file path comments", () {
+    final result = generateAssetsClass(
+      [
+        Asset(
+            name: "file",
+            path: "lib/path/file.txt",
+            fileUri: "file:///Users/user/path/lib/path/file.txt",
+            type: AssetType.stringPath)
+      ],
+      addFilePathComments: false,
+    );
+    expect(result.length, 1);
+    expect(result[0].imports, []);
+    expect(result[0].code, """class Assets {
+  static const String file = "lib/path/file.txt";
+}
+""");
+  });
+
+  test("test multiple simple assets without file path comments", () {
+    final result = generateAssetsClass(
+      [
+        Asset(
+          name: "file",
+          path: "lib/path/file.txt",
+          fileUri: "file:///Users/user/path/lib/path/file.txt",
+          type: AssetType.stringPath,
+        ),
+        Asset(
+          name: "file2",
+          path: "lib/path/file2.txt",
+          fileUri: "file:///Users/user/path/lib/path/file.txt",
+          type: AssetType.stringPath,
+        ),
+        Asset(
+          name: "image",
+          path: "lib/path/file.png",
+          fileUri: "file:///Users/user/path/lib/path/image.png",
+          type: AssetType.image,
+        ),
+        Asset(
+          name: "image2",
+          path: "lib/path/image2.png",
+          fileUri: "file:///Users/user/path/lib/path/image2.png",
+          type: AssetType.image,
+        ),
+        Asset(
+          name: "svgfile",
+          path: "lib/path/svgfile.svg",
+          fileUri: "file:///Users/user/path/lib/path/svgfile.svg",
+          type: const CustomAssetType(
+            "SvgFile",
+            ".svg",
+            "asset_classes.dart",
+          ),
+        )
+      ],
+      addFilePathComments: false,
+    );
+    expect(result.length, 2);
+    expect(result[0].imports, ['asset_classes.dart']);
+    expect(result[0].code, """class Assets {
+  static const String file = "lib/path/file.txt";
+  static const String file2 = "lib/path/file2.txt";
+  static const SvgFile svgfile = SvgFile("lib/path/svgfile.svg");
+}
+""");
+
+    expect(result[1].imports, ['package:flutter/widgets.dart']);
+    expect(result[1].code, """class Images {
+  static AssetImage get image => const AssetImage("lib/path/file.png");
+  static AssetImage get image2 => const AssetImage("lib/path/image2.png");
+}
+""");
+  });
 }


### PR DESCRIPTION
This flag `add_file_path_comments` would allow the user to decide if they want the file path comments or not.
This is because when working in a team using multiple machines, there is no use of these comments.
```
  /// ![](file:///Users/khaleel/my_app/assets/svg/img.svg)
```