### PR TITLE
Add support for flavor path field to the asset parser

### DIFF
--- a/lib/src/parser/assets_parser.dart
+++ b/lib/src/parser/assets_parser.dart
@@ -20,12 +20,22 @@ Assets parseAssets(YamlMap yaml, List<String> ignoreAssets,
   final assetFiles = <File>{};
   final declared = <String>[];
   for (final asset in assets) {
+    String? assetPath;
+
     if (asset is String) {
-      if (assetShouldBeIgnored(asset, ignoreAssets)) {
+      assetPath = asset;
+    } else if (asset is YamlMap) {
+      if (asset.containsKey('path')) {
+        assetPath = asset.value['path'];
+      }
+    }
+
+    if (assetPath != null) {
+      if (assetShouldBeIgnored(assetPath, ignoreAssets)) {
         continue;
       }
-      declared.add(asset);
-      assetFiles.addAll(_findFiles(asset, ignoreAssets));
+      declared.add(assetPath);
+      assetFiles.addAll(_findFiles(assetPath, ignoreAssets));
     }
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,12 +11,12 @@ dependencies:
   path: '>=0.9.0 <2.0.0'
   yaml: ^3.1.0
   recase: '>=4.0.0 < 5.0.0'
-  build: '>=2.0.0 <3.0.0'
+  build: ^4.0.0
   build_config: '>=1.0.0 <2.0.0'
   collection: ^1.15.0
   glob: ^2.0.0
 
 dev_dependencies:
   test: any
-  build_test: ^2.0.0
+  build_test: ^3.0.0
   lint: ^1.0.0

--- a/runtime_arb/pubspec.yaml
+++ b/runtime_arb/pubspec.yaml
@@ -1,11 +1,10 @@
 name: runtime_arb
 description: A new Flutter package project.
 version: 0.0.1
-author:
 homepage:
 
 environment:
-  sdk: ">=2.1.0 <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
This change adds support for the flavor path field to the asset parser.

Flutter added support for excluding assets for certain flavors:
https://docs.flutter.dev/tools/pubspec#assets